### PR TITLE
issue/2799 Removed redundant behaviour

### DIFF
--- a/js/YouTubeView.js
+++ b/js/YouTubeView.js
@@ -1,4 +1,6 @@
+import a11y from 'core/js/a11y';
 import Adapt from 'core/js/adapt';
+import logging from 'core/js/logging';
 import ComponentView from 'core/js/views/componentView';
 
 export default class YouTubeView extends ComponentView {
@@ -22,7 +24,7 @@ export default class YouTubeView extends ComponentView {
     this.debouncedTriggerGlobalEvent = _.debounce(this.triggerGlobalEvent.bind(this), 1000);
     if (window.onYouTubeIframeAPIReady !== undefined) return;
     window.onYouTubeIframeAPIReady = () => {
-      Adapt.log.info('YouTube iframe API loaded');
+      logging.info('YouTube iframe API loaded');
       Adapt.youTubeIframeAPIReady = true;
       Adapt.trigger('youTubeIframeAPIReady');
     };
@@ -133,7 +135,7 @@ export default class YouTubeView extends ComponentView {
     // need slight delay before focussing button to make it work when JAWS is running
     // see https://github.com/adaptlearning/adapt_framework/issues/2427
     _.delay(() => {
-      Adapt.a11y.focusFirst(this.$('.youtube__transcript-btn'), { defer: true });
+      a11y.focusFirst(this.$('.youtube__transcript-btn'), { defer: true });
     }, 250);
   }
 

--- a/js/adapt-youtube.js
+++ b/js/adapt-youtube.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import ComponentModel from 'core/js/models/componentModel';
 import YouTubeView from './YouTubeView';
 
-export default Adapt.register('youtube', {
+export default components.register('youtube', {
   model: ComponentModel.extend({}),
   view: YouTubeView
 });


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Switched to components.register from Adapt.register
* Use `a11y` and `logging` directly