### PR TITLE
Fix: Add clipboard-write permission (fix #41)

### DIFF
--- a/templates/youtube.hbs
+++ b/templates/youtube.hbs
@@ -23,7 +23,7 @@
       &playsinline={{#if _media._playsinline}}1{{else}}0{{/if~}}
       &enablejsapi=1&iv_load_policy={{#if _media._showAnnotations}}1{{else}}3{{/if~}}"
       {{#if _media._allowFullscreen}} allowfullscreen="true"{{/if}}
-      allow="clipboard-write; autoplay;"
+      allow="clipboard-write; autoplay; encrypted-media;"
       frameborder="0">
     </iframe>
     {{else}}

--- a/templates/youtube.hbs
+++ b/templates/youtube.hbs
@@ -23,6 +23,7 @@
       &playsinline={{#if _media._playsinline}}1{{else}}0{{/if~}}
       &enablejsapi=1&iv_load_policy={{#if _media._showAnnotations}}1{{else}}3{{/if~}}"
       {{#if _media._allowFullscreen}} allowfullscreen="true"{{/if}}
+      allow="clipboard-write"
       frameborder="0">
     </iframe>
     {{else}}

--- a/templates/youtube.hbs
+++ b/templates/youtube.hbs
@@ -23,7 +23,7 @@
       &playsinline={{#if _media._playsinline}}1{{else}}0{{/if~}}
       &enablejsapi=1&iv_load_policy={{#if _media._showAnnotations}}1{{else}}3{{/if~}}"
       {{#if _media._allowFullscreen}} allowfullscreen="true"{{/if}}
-      allow="clipboard-write"
+      allow="clipboard-write; autoplay;"
       frameborder="0">
     </iframe>
     {{else}}


### PR DESCRIPTION
Fix #41 

### Fix
* Add [`clipboard-write` permission](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#permission-aware_apis) to allow for copying the YouTube link.

Not related to original issue:
* [Allow `autoplay`](https://developers.google.com/youtube/player_parameters?_gl=1*1snacte*_up*MQ..*_ga*MTc0MTYzNDY0LjE3NzgwOTQxNDg.*_ga_SM8HXJ53K2*czE3NzgwOTQxNDgkbzEkZzAkdDE3NzgwOTQxNDgkajYwJGwwJGgw#Parameters). Chrome blocks autoplay in iframes by default unless the allow="autoplay" permission is present. Without it, &autoplay=1 is silently ignored in Chrome regardless of value.
* [Add `encrypted-media`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy/encrypted-media) permission to prevent HD playback from silently failing on some browsers