### PR TITLE
Fix: Loop single videos via the player API (fixes #45)

### DIFF
--- a/js/YouTubeView.js
+++ b/js/YouTubeView.js
@@ -124,6 +124,11 @@ export default class YouTubeView extends ComponentView {
         break;
       case window.YT.PlayerState.ENDED:
         this.triggerGlobalEvent('ended');
+        if (this.model.get('_media')._loop) {
+          this.player.seekTo(0);
+          this.player.playVideo();
+          return;
+        }
         if (this.model.get('_setCompletionOn') === 'ended') {
           this.setCompletionStatus();
         }
@@ -168,7 +173,7 @@ export default class YouTubeView extends ComponentView {
     $buttonText.html(this.model.get('_transcript').inlineTranscriptCloseButton);
     this.transcriptTriggers('opened');
   }
-  
+
   onExternalTranscriptClicked(event) {
     this.transcriptTriggers('external');
   }

--- a/templates/youtube.hbs
+++ b/templates/youtube.hbs
@@ -16,7 +16,6 @@
       src="{{_media._source~}}
       ?&autoplay={{#if _media._autoplay}}1{{else}}0{{/if~}}
       &rel={{#if _media._showRelated}}1{{else}}0{{/if~}}
-      &loop={{#if _loop}}1{{else}}0{{/if~}}
       &modestbranding={{#if _media._modestBranding}}1{{else}}0{{/if~}}
       &color={{#if _media._progressColor}}{{_media._progressColor}}{{/if~}}
       &controls={{#if _media._controls}}1{{else}}0{{/if~}}


### PR DESCRIPTION
Fixes #45

### Fix
- Loop now works when `_media._loop` is enabled. On the `ENDED` player state, if looping is enabled the player seeks to the start and plays again.
- Removed the `&loop=` URL parameter from the iframe `src`. It read the wrong config path (`_loop` instead of `_media._loop`) and, more importantly, URL-based looping suppresses the `ENDED` event the handler relies on. The single-video `playlist=` requirement is also avoided, which previously caused a blank `playlist=` and a "Video unavailable" error.

### Testing

1. Add a YouTube component, set `_media._loop` to `true`, point `_media._source` at any embeddable video (ex. //www.youtube.com/embed/jNQXAC9IVRw )
2. Watch to the end. The video restarts and plays again.
3. Confirm the iframe `src` no longer contains `loop=` or `playlist=`, and there is no "Video unavailable" error.
4. With `_media._loop` set to `false`, the video stops at the end as before (and completes if `_setCompletionOn` is `ended`).

Note: `_setCompletionOn: "ended"` combined with `_media._loop: true` will never complete, as a looping video never reaches a final end. This is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)