### PR TITLE
Update: Align 'skip to transcript' styles with Media (fixes #36)

### DIFF
--- a/less/youtube.less
+++ b/less/youtube.less
@@ -60,16 +60,12 @@
 
   // Skip to transcript button
   &__skip-to-transcript {
+    margin-bottom: @item-margin;
 
     html:not(.has-accessibility) & {
       .u-display-none;
     }
 
-    &:not(:focus-visible) {
-      height: 0;
-      padding: 0;
-      margin: 0;
-      overflow: hidden;
-    }
+    .visually-hidden-focusable;
   }
 }


### PR DESCRIPTION
Fixes #36

### Update
Align the "skip to transcript" button styles with the latest Media component accessibility approach:
- Replace the `:not(:focus-visible)` visually-hidden rules with the core `.visually-hidden-focusable` mixin.
- Add `margin-bottom: @item-margin` so the button has spacing when focused and visible.

### Testing
1. Build a course with a YouTube component that has a transcript enabled.
2. Using keyboard navigation, Tab until you reach the "Skip to transcript" button.
3. Confirm the button stays hidden until focused, appears with correct spacing on focus, and moves focus to the transcript on activation.

Posted via collaboration with Claude Code