### PR TITLE
Fix: Add aria-label to YouTube iframe for screen readers (fixes #22)

### DIFF
--- a/templates/youtube.hbs
+++ b/templates/youtube.hbs
@@ -22,7 +22,7 @@
       &controls={{#if _media._controls}}1{{else}}0{{/if~}}
       &playsinline={{#if _media._playsinline}}1{{else}}0{{/if~}}
       &enablejsapi=1&iv_load_policy={{#if _media._showAnnotations}}1{{else}}3{{/if~}}"
-      {{#if displayTitle}}aria-label="{{displayTitle}}"{{else}}{{#if title}}aria-label="{{title}}"{{/if}}{{/if}}
+      {{#if displayTitle}}aria-labelledby="{{_id}}-heading"{{else}}{{#if title}}aria-label="{{title}}"{{/if}}{{/if}}
       {{#if _media._allowFullscreen}} allowfullscreen="true"{{/if}}
       allow="clipboard-write; autoplay; encrypted-media;"
       frameborder="0">

--- a/templates/youtube.hbs
+++ b/templates/youtube.hbs
@@ -22,6 +22,7 @@
       &controls={{#if _media._controls}}1{{else}}0{{/if~}}
       &playsinline={{#if _media._playsinline}}1{{else}}0{{/if~}}
       &enablejsapi=1&iv_load_policy={{#if _media._showAnnotations}}1{{else}}3{{/if~}}"
+      {{#if displayTitle}}aria-label="{{displayTitle}}"{{else}}{{#if title}}aria-label="{{title}}"{{/if}}{{/if}}
       {{#if _media._allowFullscreen}} allowfullscreen="true"{{/if}}
       allow="clipboard-write; autoplay; encrypted-media;"
       frameborder="0">


### PR DESCRIPTION
Fixes #22

### Fix
- Add an author-controlled, localisable `aria-label` to the YouTube `<iframe>`, taken from the component's `displayTitle` (falling back to `title`).

### Notes
Previously the iframe had no author-set accessible name. The only name was a `title` attribute injected at runtime by the YouTube widget API, set to the video's own YouTube title, which authors cannot control or localise. The new `aria-label` takes precedence in the accessible name computation, so screen readers announce the component's title instead.

Per the discussion on #22, `aria-label` is used rather than `title` (as `title` behaves inconsistently on iframes). This mirrors the approach already used in adapt-contrib-media (adaptlearning/adapt_framework#2822). Relevant WCAG success criterion: 4.1.2 Name, Role, Value (technique H64).

The label is only emitted when `displayTitle` or `title` is set, so no empty `aria-label=""` is produced.

### Testing
1. Add a YouTube component with a `displayTitle` set.
2. View the page and inspect the rendered `<iframe>` inside `.youtube__widget`.
3. Confirm it has `aria-label` matching the component's `displayTitle`.
4. With a screen reader, confirm the iframe is announced using that title.

Posted via collaboration with Claude Code