### PR TITLE
Fix: set referrerpolicy on embed iframe to prevent Error 153 (fix #51)

### DIFF
--- a/templates/youtube.hbs
+++ b/templates/youtube.hbs
@@ -13,6 +13,7 @@
 
     {{#if _media._source}}
     <iframe width="640px" height="360px" style="width:100%;"
+      referrerpolicy="strict-origin-when-cross-origin"
       src="{{_media._source~}}
       ?&autoplay={{#if _media._autoplay}}1{{else}}0{{/if~}}
       &rel={{#if _media._showRelated}}1{{else}}0{{/if~}}


### PR DESCRIPTION
Fixes #51

### Fix
* Set `referrerpolicy="strict-origin-when-cross-origin"` on the YouTube embed iframe so it still sends a `Referer` when the host page's own referrer policy would otherwise suppress it. Without a `Referer`, YouTube rejects the embed with Error 153 (per [YouTube's client-identity policy](https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity), which itself recommends this exact policy value). See #51 for the full root-cause writeup and evidence.

### Testing
1. Add `<meta name="referrer" content="same-origin">` to a course's `index.html` to simulate a host that restricts its referrer policy.
2. Load a page with a YouTube component. Without this fix: embed request has no `Referer` header, YouTube returns Error 153.
3. With this fix: iframe sends `Referer` (origin only), embed plays normally. Confirmed via DevTools network inspection — the iframe attribute overrides the document-level policy for that request only, so no other requests are affected.

---

*Posted via collaboration with Claude Code*
